### PR TITLE
Add list of accepted flags in Language Syntax doc

### DIFF
--- a/docs/beancount_language_syntax.md
+++ b/docs/beancount_language_syntax.md
@@ -336,7 +336,9 @@ As for all the other directives, a transaction directive begins with a date in t
       Liabilities:CreditCard:CapitalOne         -37.45 USD
       Expenses:Restaurant
 
-A flag is used to indicate the status of a transaction, and the particular meaning of the flag is yours to define. We recommend using the following interpretation for them:
+A flag is a character used to indicate the status of a transaction. The characters accepted as flags are `*`, `!`, `P`, `S`, `T`, `C`, `U`, `R` and `M`.
+
+The particular meaning of the flag is yours to define. We recommend using the following interpretation for them:
 
 -   *: Completed transaction, known amounts, “this looks correct.”
 


### PR DESCRIPTION
This PR because I had a hard time to find the list of accepted flags.
I found the list at https://github.com/beancount/beancount/tree/dda30838ce90f388a3b8e22eff9052eec6a6a9f2/beancount/core/flags.py#L7-20