### PR TITLE
Fix code format

### DIFF
--- a/docs/command_line_accounting_in_context.md
+++ b/docs/command_line_accounting_in_context.md
@@ -178,15 +178,16 @@ The beauty of it is that once you have the corpus of data, which is relatively e
 
 1.  **By providing a “plugins” system** that allows you to filter a parsed set of transactions. This makes it possible for you to hack the syntax of Beancount and prototype new conveniences in data entry. Plugins provided by default provide extended features just by filtering and transforming the list of parsed transactions. And it’s simple: all you have to do is implement a callback function with a particular signature and add a line to your input file.
 
-2.  **By writing scripts.** You can parse and obtain the contents of a ledger with very little code. In Python, this looks no more complicated than this:  
-      
-    import beancount.loader  
-    …  
-    entries, errors, options = beancount.loader.load\_file('myfile.ledger')
+2.  **By writing scripts.** You can parse and obtain the contents of a ledger with very little code. In Python, this looks no more complicated than this:
 
 <!-- -->
 
-      for entry in entries:
+    import beancount.loader  
+    …
+
+    entries, errors, options = beancount.loader.load_file('myfile.ledger')
+
+    for entry in entries:
         …
 
 Voila. You’re on your way to spitting out whatever output you want. You have access to all the libraries in the Python world, and my code is mostly functional, heavily documented and thoroughly unit-tested. You should be able to find your way easily. Moreover, if you’re uncertain about using this system, you could just use it to begin entering your data and later write a script that converts it into something else.


### PR DESCRIPTION
Reading the docs, I realized that the code sample pin section [Custom Scripting](https://beancount.github.io/docs/command_line_accounting_in_context.html#custom-scripting), had misformatting, as shown bellow:

![Screen Shot 2021-04-21 at 15 08 12](https://user-images.githubusercontent.com/358777/115600858-80484e00-a2b3-11eb-9a1c-a83c8fab2d93.png)

After format fix, It would be something like this:

![Screen Shot 2021-04-21 at 15 10 05](https://user-images.githubusercontent.com/358777/115601019-ad94fc00-a2b3-11eb-8173-3f12a7b1cd94.png)
