### PR TITLE
Updating URLs and adding backticks

### DIFF
--- a/docs/beancount_query_language.md
+++ b/docs/beancount_query_language.md
@@ -18,7 +18,7 @@ This document describes our specialized SQL-like query client. It assumes you ha
 
 So one might ask: Why create another SQL client? Why not output the data to an SQLite database and allow the user to use that SQL client?
 
-Well, we have done that (see the [<u>bean-sql</u>](https://github.com/beancount/beancount/tree/v2/beancount/scripts/sql.py) script which converts your Beancount ledger into an SQLite database) and the results are not great. Writing queries is painful and carrying out operations on lots that are held at cost is difficult. By taking advantage of a few aspects of our in-memory data structures, we can do better. So Beancount comes with its own SQL-like query client called “[<u>bean-query</u>](https://github.com/beancount/beancount/tree/master/beancount/scripts/query.py)”.
+Well, we have done that (see the [<u>bean-sql</u>](https://github.com/beancount/beancount/tree/v2/beancount/scripts/sql.py) script which converts your Beancount ledger into an SQLite database) and the results are not great. Writing queries is painful and carrying out operations on lots that are held at cost is difficult. By taking advantage of a few aspects of our in-memory data structures, we can do better. So Beancount comes with its own SQL-like query client called “[<u>bean-query</u>](https://github.com/beancount/beanquery)”.
 
 The clients implements the following “extras” that are essential to Beancount:
 
@@ -221,23 +221,23 @@ Refer to the table below for explicit examples of each type of posting and how i
 
 Common comparison and logical operators are provided to operate on the available data columns:
 
--   = (equality), != (inequality)
+-   `=` (equality), `!=` (inequality)
 
--   < (less than), <= (less than or equal)
+-   `<` (less than), `<=` (less than or equal)
 
--   > (greater than), >= (greater than or equal)
+-   `>` (greater than), `>=` (greater than or equal)
 
--   AND (logical conjunction)
+-   `AND` (logical conjunction)
 
--   OR (logical disjunction)
+-   `OR` (logical disjunction)
 
--   NOT (logical negation)
+-   `NOT` (logical negation)
 
--   IN (set membership)
+-   `IN` (set membership)
 
 We also provide a regular expression search operator into a string object:
 
--   ~ (search regexp)
+-   `~` (search regexp)
 
 At the moment, matching groups are ignored.
 
@@ -543,7 +543,7 @@ The ability to select from the result of another `SELECT` is not currently suppo
 
 ## More Information<a id="more-information"></a>
 
-This document attempts to provide a good high-level summary of the features supported in our query language. However, should you find you need more information, you may take a look at the [<u>original proposal</u>](http://furius.ca/beancount/doc/proposal-query), or consult the source code under the [<u>beancount.query</u>](https://github.com/beancount/beancount/tree/v2/beancount/query/) directory. In particular, the [<u>parser</u>](https://github.com/beancount/beancount/tree/master/beancount/parser) will provide insight into the specifics of the syntax, and the [<u>environments</u>](https://github.com/beancount/beancount/tree/v2/beancount/query/query_env.py) will shed some light on the supported data columns and functions. Feel free to rummage in the source code and ask questions on the mailing-list.
+This document attempts to provide a good high-level summary of the features supported in our query language. However, should you find you need more information, you may take a look at the [<u>original proposal</u>](http://furius.ca/beancount/doc/proposal-query), or consult the source code in the [<u>beanquery</u>](https://github.com/beancount/beanquery) repository. In particular, the [<u>parser tests</u>](https://github.com/beancount/beanquery/blob/master/beanquery/parser_test.py) will provide insight into the specifics of the syntax, and the [<u>query env tests</u>](https://github.com/beancount/beanquery/blob/master/beanquery/query_env_test.py) will shed some light on the supported data columns and functions. Feel free to rummage in the source code and ask questions on the mailing-list.
 
 ## Appendix<a id="appendix"></a>
 


### PR DESCRIPTION
Updating URLs to reflect that beanquery is now in its own repository, and providing URLs to tests which are hopefully easier to read as a reference.

Also, unrelated, adding back-ticks.